### PR TITLE
Fix streaming artifacts in Sesame TTS

### DIFF
--- a/mlx_audio/codec/models/__init__.py
+++ b/mlx_audio/codec/models/__init__.py
@@ -1,5 +1,5 @@
 from .descript import DAC
 from .encodec import Encodec
-from .mimi import Mimi
+from .mimi import Mimi, MimiStreamingDecoder
 from .snac import SNAC
 from .vocos import Vocos

--- a/mlx_audio/codec/models/mimi/__init__.py
+++ b/mlx_audio/codec/models/mimi/__init__.py
@@ -1,1 +1,1 @@
-from .mimi import Mimi
+from .mimi import Mimi, MimiStreamingDecoder

--- a/mlx_audio/codec/models/mimi/mimi.py
+++ b/mlx_audio/codec/models/mimi/mimi.py
@@ -9,6 +9,54 @@ import mlx.core as mx
 import mlx.nn as nn
 from huggingface_hub import hf_hub_download
 
+
+class MimiStreamingDecoder:
+    """Incremental decoder wrapper for the Mimi codec.
+
+    This helper keeps the internal state of the Mimi model across calls and
+    decodes audio tokens frame by frame using ``decode_step``.  It is useful in
+    streaming settings where resetting the codec state for every chunk would
+    introduce audible artifacts.
+    """
+
+    def __init__(self, mimi: "Mimi") -> None:  # noqa: F821 - Mimi defined below
+        self._mimi = mimi
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset the underlying codec state."""
+        self._mimi.decoder.reset_state()
+        self._mimi.upsample.reset_state()
+        for c in self._mimi.decoder_cache:
+            c.reset()
+
+    def decode_frames(self, tokens: mx.array) -> mx.array:
+        """Decode a sequence of audio tokens incrementally.
+
+        Parameters
+        ----------
+        tokens:
+            Array of shape ``(B, C, T)`` or ``(C, T)`` containing the audio
+            tokens to decode. ``B`` is the batch dimension, ``C`` is the number
+            of codebooks and ``T`` the number of frames.
+
+        Returns
+        -------
+        mx.array
+            The decoded waveform for the provided frames.
+        """
+
+        if tokens.ndim == 2:
+            tokens = mx.expand_dims(tokens, 0)
+
+        pcm = []
+        for t in range(tokens.shape[-1]):
+            step_tokens = tokens[:, :, t : t + 1]
+            pcm.append(self._mimi.decode_step(step_tokens))
+
+        return mx.concat(pcm, axis=-1)
+
+
 from .modules import (
     ConvDownsample1d,
     ConvTrUpsample1d,

--- a/mlx_audio/tts/models/sesame/sesame.py
+++ b/mlx_audio/tts/models/sesame/sesame.py
@@ -19,7 +19,7 @@ from tokenizers.processors import TemplateProcessing
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
-from mlx_audio.codec import Mimi
+from mlx_audio.codec import Mimi, MimiStreamingDecoder
 
 from ..base import GenerationResult
 from .attention import Attention
@@ -302,6 +302,7 @@ class Model(nn.Module):
         self._text_tokenizer = load_llama3_tokenizer(TOKENIZER_REPO)
         mimi = Mimi.from_pretrained(MIMI_REPO)
         self._audio_tokenizer = mimi
+        self._streaming_decoder = MimiStreamingDecoder(mimi)
 
         try:
             self._watermarker = load_watermarker()
@@ -450,10 +451,17 @@ class Model(nn.Module):
         )
         return [prompt]
 
-    def generate_result(self, samples, start_time: float) -> GenerationResult:
+    def generate_result(
+        self, samples, start_time: float, stream: bool = False
+    ) -> GenerationResult:
         token_count = len(samples)
         transposed = mx.transpose(mx.stack(samples), axes=[1, 2, 0])
-        audio = self._audio_tokenizer.decode(transposed).squeeze(0).squeeze(0)
+        if stream:
+            audio = (
+                self._streaming_decoder.decode_frames(transposed).squeeze(0).squeeze(0)
+            )
+        else:
+            audio = self._audio_tokenizer.decode(transposed).squeeze(0).squeeze(0)
 
         # This applies an imperceptible watermark to identify audio as AI-generated.
         # Watermarking ensures transparency, dissuades misuse, and enables traceability.
@@ -548,6 +556,8 @@ class Model(nn.Module):
             start_time = time.perf_counter()
 
             self.model.reset_caches()
+            if stream:
+                self._streaming_decoder.reset()
 
             tokens, tokens_mask = [], []
             for segment in context:
@@ -612,12 +622,12 @@ class Model(nn.Module):
                     >= streaming_interval_tokens
                 ):
                     yielded_frame_count = generated_frame_count
-                    yield self.generate_result(samples, start_time)
+                    yield self.generate_result(samples, start_time, stream=True)
                     samples = []
                     start_time = time.perf_counter()
 
             if len(samples) > 0:
-                yield self.generate_result(samples, start_time)
+                yield self.generate_result(samples, start_time, stream=stream)
 
             # Clear cache after each segment to avoid memory leaks
             mx.clear_cache()


### PR DESCRIPTION
## Summary
- add `MimiStreamingDecoder` to maintain codec state between chunks
- expose the new streaming decoder in codec package
- use the streaming decoder in Sesame TTS generation

## Testing
- `pytest -q` *(fails: command not found)*