### PR TITLE
Improve streaming audio playback

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -295,7 +295,10 @@ def generate_audio(
         file_name = f"{file_prefix}.{audio_format}"
         for i, result in enumerate(results):
             if play:
-                player.queue_audio(result.audio)
+                if stream:
+                    player.queue_audio_async(result.audio)
+                else:
+                    player.queue_audio(result.audio)
 
             if join_audio:
                 audio_list.append(result.audio)


### PR DESCRIPTION
## Summary
- queue audio buffers asynchronously to avoid stalls when streaming
- use async queue when generating streamed audio

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*